### PR TITLE
Fix ROM load performance and clean up types

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import ControlPanel from './components/ControlPanel';
 import GameLog from './components/GameLog';
 import GameBoyControls from './components/GameBoyControls';
 import { APP_VERSION } from "./version";
-import { useGameStore, type GameState, type LogEntry, type AIConfig } from './store/gameStore';
+import { useGameStore, type GameState, type AIConfig } from './store/gameStore';
 
 function App() {
   const {
@@ -14,7 +14,6 @@ function App() {
     aiEnabled,
     currentGame,
     gameData,
-    screen,
     aiStatus,
     logs,
     isMuted,
@@ -27,19 +26,19 @@ function App() {
     addLog,
     clearLogs,
     updateAIConfig,
-    updateScreen,
     setAIStatus
   } = useGameStore();
 
   const emulatorRef = useRef<GameBoyEmulatorRef>(null);
   const aiControllerRef = useRef<AIControllerRef>(null);
+  const screenRef = useRef<ImageData | null>(null);
 
   const handleGameLoad = (gameData: Uint8Array, fileName: string) => {
     loadGame(gameData, fileName);
   };
 
   const handleScreenUpdate = (screen: ImageData) => {
-    updateScreen(screen);
+    screenRef.current = screen;
   };
 
   const handleManualButtonPress = (button: string) => {
@@ -162,14 +161,14 @@ function App() {
           />
         </div>
         <div>
-          <ControlPanel aiConfig={aiConfig} onConfigChange={handleAIConfigChange} gameState={{ isPlaying, aiEnabled, currentGame, gameData, screen, aiStatus, logs }} />
+          <ControlPanel aiConfig={aiConfig} onConfigChange={handleAIConfigChange} gameState={{ isPlaying, aiEnabled, currentGame, gameData, aiStatus, logs, isMuted, aiConfig }} />
           <GameLog logs={logs} onClearLogs={clearLogs} />
         </div>
       </div>
       <AIController
         ref={aiControllerRef}
         config={aiConfig}
-        gameState={{ isPlaying, aiEnabled, currentGame, gameData, screen, aiStatus, logs }}
+        gameState={{ isPlaying, aiEnabled, currentGame, gameData, aiStatus, logs, isMuted, aiConfig }}
         onStatusChange={handleAIStatusChange}
         onLog={addLog}
         emulatorRef={emulatorRef}

--- a/src/components/AIController.tsx
+++ b/src/components/AIController.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, useImperativeHandle, useRef } from 'react';
 import axios from 'axios';
-import { AIConfig, GameState, LogEntry } from '../App';
+import { AIConfig, GameState, LogEntry } from '../store/gameStore';
 import { GameBoyEmulatorRef } from './GameBoyEmulator'; // Import GameBoyEmulatorRef
 
 interface AIControllerProps {
@@ -98,16 +98,7 @@ const AIController = forwardRef<AIControllerRef, AIControllerProps>(
       // Start the AI decision loop with async function
       const aiLoop = async () => {
         while (isPlayingRef.current && gameState.aiEnabled && gameState.isPlaying) {
-          const currentConditions = {
-            isPlayingRef: isPlayingRef.current,
-            aiEnabled: gameState.aiEnabled, 
-            gameIsPlaying: gameState.isPlaying,
-            hasApiKey: !!config.apiKey,
-            hasGame: !!gameState.currentGame,
-            emulatorReady: emulatorRef.current?.isReady?.() || false
-          };
-          
-          // console.log('AIController: AI loop tick', currentConditions);
+          // console.log('AIController: AI loop tick');
           
           if (!isPlayingRef.current) {
             // console.log('AIController: Stopping - AI loop not active');

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Settings, Cpu } from 'lucide-react';
-import { AIConfig, GameState } from '../App';
+import { AIConfig, GameState } from '../store/gameStore';
 
 interface ControlPanelProps {
   aiConfig: AIConfig;

--- a/src/components/GameBoyEmulator.tsx
+++ b/src/components/GameBoyEmulator.tsx
@@ -315,7 +315,7 @@ const GameBoyEmulator = forwardRef<GameBoyEmulatorRef, GameBoyEmulatorProps>(
         }
       };
       (window as any).debugCanvas = () => { /* ... */ };
-      (window as any).testAllInputMethods = async (button = 'START') => { /* ... */ };
+      (window as any).testAllInputMethods = async (_button = 'START') => { /* ... */ };
       // console.log('✅ Debug functions available in development mode.');
       return () => {
         // console.log('Cleaning up debug functions');
@@ -456,17 +456,6 @@ const GameBoyEmulator = forwardRef<GameBoyEmulatorRef, GameBoyEmulatorProps>(
       console.error('Game load error:', error);
     };
 
-    const onCanvasShow = () => {
-      console.log('Canvas is showing');
-    };
-
-    const onCanvasHide = () => {
-      console.log('Canvas is hiding');
-    };
-
-    const onAudioWorks = () => {
-      console.log('Audio is working');
-    };
 
     return (
       <div style={{

--- a/src/components/GameLog.tsx
+++ b/src/components/GameLog.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { LogEntry } from '../App';
+import { LogEntry } from '../store/gameStore';
 
 interface GameLogProps {
   logs: LogEntry[];

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -19,7 +19,6 @@ export interface GameState {
   aiEnabled: boolean;
   currentGame: string | null;
   gameData: Uint8Array | null;
-  screen: ImageData | null;
   aiStatus: 'idle' | 'thinking' | 'playing' | 'error';
   logs: LogEntry[];
   isMuted: boolean;
@@ -35,16 +34,14 @@ type GameStore = GameState & {
   addLog: (type: LogEntry['type'], message: string) => void;
   clearLogs: () => void;
   updateAIConfig: (config: AIConfig) => void;
-  updateScreen: (screen: ImageData) => void;
   setAIStatus: (status: GameState['aiStatus']) => void;
-};
+}; 
 
 const initialState: GameState = {
   isPlaying: false,
   aiEnabled: false,
   currentGame: null,
   gameData: null,
-  screen: null,
   aiStatus: 'idle',
   logs: [],
   isMuted: false,
@@ -140,10 +137,6 @@ export const useGameStore = create<GameStore>()(
             get().addLog('info', 'API key saved locally');
           }
         }
-      },
-      
-      updateScreen: (screen: ImageData) => {
-        set({ screen });
       },
       
       setAIStatus: (status: GameState['aiStatus']) => {


### PR DESCRIPTION
## Summary
- remove screen from global state to avoid heavy renders
- keep latest screen in a ref instead of the store
- clean up type imports across components
- silence unused variables

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_683f5618e7a8832fbdeae414e5f84d76