### PR TITLE
Fix emulator readiness check

### DIFF
--- a/src/components/GameBoyEmulator.tsx
+++ b/src/components/GameBoyEmulator.tsx
@@ -387,7 +387,8 @@ const GameBoyEmulator = forwardRef<GameBoyEmulatorRef, GameBoyEmulatorProps>(
         }
       },
       getScreenData,
-      isReady: () => wasmBoyInitialized.current && WasmBoy.isReady()
+      // Consider the emulator ready only once a ROM is loaded and started
+      isReady: () => wasmBoyInitialized.current && WasmBoy.isLoadedAndStarted()
     }));
 
     const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Summary
- ensure the emulator is fully loaded and started before the AI sends inputs

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_683f5a376238832f955803ecc6fa241d