### PR TITLE
Improve layout with larger emulator

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -119,7 +119,7 @@ function App() {
           Watch AI play classic GameBoy games using OpenRouter
         </p>
       </header>
-      <div className="grid grid-2">
+      <div className="grid grid-3">
         <div>
           <GameBoyEmulator
             ref={emulatorRef}
@@ -129,6 +129,8 @@ function App() {
             onScreenUpdate={handleScreenUpdate}
             onGameLoad={handleGameLoad}
           />
+        </div>
+        <div>
           <div className="controls-panel">
             <div style={{ display: 'flex', gap: '12px', marginBottom: '16px' }}>
               <button className="button" onClick={togglePlayPause} disabled={!currentGame}>
@@ -150,8 +152,8 @@ function App() {
               AI Status: {aiStatus}
               {aiEnabled && currentGame && (
                 <div style={{ fontSize: '10px', marginTop: '4px', opacity: 0.8 }}>
-                  {isPlaying ? 'Game is playing' : 'Game is paused'} • 
-                  {aiConfig.apiKey ? 'API key set' : 'No API key'} • 
+                  {isPlaying ? 'Game is playing' : 'Game is paused'} •
+                  {aiConfig.apiKey ? 'API key set' : 'No API key'} •
                   Model: {aiConfig.model.split('/').pop()}
                 </div>
               )}

--- a/src/components/GameBoyEmulator.tsx
+++ b/src/components/GameBoyEmulator.tsx
@@ -452,7 +452,7 @@ const GameBoyEmulator = forwardRef<GameBoyEmulatorRef, GameBoyEmulatorProps>(
         borderRadius: '12px',
         boxShadow: '0 8px 32px rgba(0,0,0,0.3)',
         border: '3px solid #7a9147',
-        maxWidth: '400px',
+        maxWidth: '480px',
         margin: '0 auto'
       }}>
         <div style={{

--- a/src/components/GameLog.tsx
+++ b/src/components/GameLog.tsx
@@ -102,7 +102,7 @@ const GameLog: React.FC<GameLogProps> = ({ logs, onClearLogs }) => {
       <div 
         ref={logContainerRef}
         style={{
-          height: '300px',
+          height: '240px',
           overflowY: 'auto',
           background: 'rgba(0,0,0,0.3)',
           borderRadius: '8px',

--- a/src/index.css
+++ b/src/index.css
@@ -178,11 +178,11 @@ body {
 }
 
 .grid-2 {
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 2fr 1fr;
 }
 
 .grid-3 {
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: 2fr 1fr 1fr;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- enlarge emulator view
- use 3-column grid layout
- adjust grid sizes in CSS
- shrink log box height

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run typecheck`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f63ad178c832f81bd75016e0f42ed