### PR TITLE
Refactor layout to fit single viewport

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,22 +105,8 @@ function App() {
   }, [currentGame, isPlaying, aiEnabled, togglePlayPause, stopGame, toggleAI]);
 
   return (
-    <div className="container">
-      <div style={{ textAlign: 'center', color: 'white', fontSize: '1.2rem', marginBottom: '0.5rem' }}>
-        DEV is the best!
-      </div>
-      <header style={{ textAlign: 'center', marginBottom: '2rem' }}>
-        <h1 style={{ color: 'white', fontSize: '2.5rem', fontWeight: 'bold', textShadow: '0 4px 8px rgba(0,0,0,0.3)', margin: '0 0 0.5rem 0' }}>
-          🎮 GameBoy AI Player
-        </h1>
-          
-        <div style={{ color: 'rgba(255,255,255,0.6)', fontSize: '0.8rem' }}>v{APP_VERSION}</div>
-        <p style={{ color: 'rgba(255,255,255,0.8)', fontSize: '1.1rem', margin: 0 }}>
-          Watch AI play classic GameBoy games using OpenRouter
-        </p>
-      </header>
-      <div className="grid grid-3">
-        <div>
+    <div className="main-container">
+      <div className="left-column">
           <GameBoyEmulator
             ref={emulatorRef}
             gameData={gameData}
@@ -129,9 +115,19 @@ function App() {
             onScreenUpdate={handleScreenUpdate}
             onGameLoad={handleGameLoad}
           />
+          <GameBoyControls
+            onButtonPress={handleManualButtonPress}
+            onButtonRelease={handleManualButtonRelease}
+            disabled={aiEnabled}
+          />
         </div>
-        <div>
-          <div className="controls-panel">
+        <div className="right-column">
+          <header style={{ textAlign: 'center', padding: '10px 0' }}>
+            <h1 style={{ color: 'white', margin: 0 }}>🎮 GameBoy AI Player</h1>
+            <div style={{ color: 'rgba(255,255,255,0.6)', fontSize: '0.8rem' }}>v{APP_VERSION}</div>
+          </header>
+
+          <section className="controls-panel">
             <div style={{ display: 'flex', gap: '12px', marginBottom: '16px' }}>
               <button className="button" onClick={togglePlayPause} disabled={!currentGame}>
                 {isPlaying ? <Pause size={16} /> : <Play size={16} />}
@@ -158,18 +154,20 @@ function App() {
                 </div>
               )}
             </div>
-          </div>
-          <GameBoyControls
-            onButtonPress={handleManualButtonPress}
-            onButtonRelease={handleManualButtonRelease}
-            disabled={aiEnabled}
-          />
+          </section>
+
+          <section>
+            <ControlPanel
+              aiConfig={aiConfig}
+              onConfigChange={handleAIConfigChange}
+              gameState={{ isPlaying, aiEnabled, currentGame, gameData, aiStatus, logs, isMuted, aiConfig }}
+            />
+          </section>
+
+          <section className="activity-log">
+            <GameLog logs={logs} onClearLogs={clearLogs} />
+          </section>
         </div>
-        <div>
-          <ControlPanel aiConfig={aiConfig} onConfigChange={handleAIConfigChange} gameState={{ isPlaying, aiEnabled, currentGame, gameData, aiStatus, logs, isMuted, aiConfig }} />
-          <GameLog logs={logs} onClearLogs={clearLogs} />
-        </div>
-      </div>
       <AIController
         ref={aiControllerRef}
         config={aiConfig}

--- a/src/components/GameBoyEmulator.tsx
+++ b/src/components/GameBoyEmulator.tsx
@@ -36,7 +36,6 @@ const GameBoyEmulator = forwardRef<GameBoyEmulatorRef, GameBoyEmulatorProps>(
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const wasmBoyInitialized = useRef(false);
     const [isInitialized, setIsInitialized] = useState(false);
-    const [testButtonPressed, setTestButtonPressed] = useState<string | null>(null);
     const [, setCurrentJoypadState] = useState<JoypadState>({ // currentJoypadState is unused
       UP: false,
       RIGHT: false,
@@ -95,7 +94,16 @@ const GameBoyEmulator = forwardRef<GameBoyEmulatorRef, GameBoyEmulatorProps>(
             await WasmBoy.config(config);
             
             // console.log('🖼️ Setting canvas for WasmBoy rendering...');
-            WasmBoy.setCanvas(canvasRef.current);
+            // Wait for WasmBoy to finish binding the canvas so our styles stick
+            await WasmBoy.setCanvas(canvasRef.current);
+            // Ensure the canvas is scaled up for better visibility
+            if (canvasRef.current) {
+              canvasRef.current.width = 480; // internal resolution
+              canvasRef.current.height = 432;
+              canvasRef.current.style.width = '480px';
+              canvasRef.current.style.height = '432px';
+              canvasRef.current.style.imageRendering = 'pixelated';
+            }
             
             // console.log('🎮 Disabling default joypad for custom input control...');
             await (WasmBoy as any).disableDefaultJoypad();
@@ -263,18 +271,6 @@ const GameBoyEmulator = forwardRef<GameBoyEmulatorRef, GameBoyEmulatorProps>(
         // console.error('Failed to get screen data:', error);
         return null;
       }
-    };
-
-    // Manual test button handler (can be removed or wrapped in dev check)
-    const handleTestButton = async (button: string) => {
-      setTestButtonPressed(button);
-      // console.log(`Manual test: Pressing ${button}`);
-      if (ref && 'current' in ref && ref.current) {
-        await ref.current.pressButton(button);
-      }
-      setTimeout(() => {
-        setTestButtonPressed(null);
-      }, 300);
     };
 
     // Debug function for testing WasmBoy directly (can be removed or wrapped in dev check)
@@ -446,15 +442,18 @@ const GameBoyEmulator = forwardRef<GameBoyEmulatorRef, GameBoyEmulatorProps>(
 
 
     return (
-      <div style={{
-        background: 'linear-gradient(145deg, #9bb563, #8faa5a)',
-        padding: '20px',
-        borderRadius: '12px',
-        boxShadow: '0 8px 32px rgba(0,0,0,0.3)',
-        border: '3px solid #7a9147',
-        maxWidth: '480px',
-        margin: '0 auto'
-      }}>
+        <div
+          style={{
+            background: 'linear-gradient(145deg, #9bb563, #8faa5a)',
+            padding: '20px',
+            borderRadius: '12px',
+            boxShadow: '0 8px 32px rgba(0,0,0,0.3)',
+            border: '3px solid #7a9147',
+            width: '480px',
+            maxWidth: '100%',
+            margin: '0 auto'
+          }}
+        >
         <div style={{
           background: '#1e2124',
           padding: '16px',
@@ -463,12 +462,13 @@ const GameBoyEmulator = forwardRef<GameBoyEmulatorRef, GameBoyEmulatorProps>(
           border: '2px solid #36393f'
         }}>
           <canvas
+            id="wasmboy-canvas"
             ref={canvasRef}
             width={160}
             height={144}
             style={{
-              width: '100%',
-              height: 'auto',
+              width: '480px',
+              height: '432px',
               imageRendering: 'pixelated',
               background: '#0f380f',
               border: '2px solid #306230'
@@ -518,85 +518,6 @@ const GameBoyEmulator = forwardRef<GameBoyEmulatorRef, GameBoyEmulatorProps>(
           </div>
         )}
 
-        {gameData && wasmBoyInitialized.current && (
-          <div style={{
-            marginTop: '12px',
-            padding: '12px',
-            background: 'rgba(155, 181, 99, 0.1)',
-            borderRadius: '4px',
-            border: '1px solid rgba(155, 181, 99, 0.3)'
-          }}>
-            <div style={{
-              fontSize: '12px',
-              fontWeight: 'bold',
-              marginBottom: '8px',
-              color: '#1e2124'
-            }}>
-              🧪 Manual Input Tests
-            </div>
-            <div style={{
-              display: 'grid',
-              gridTemplateColumns: 'repeat(4, 1fr)',
-              gap: '4px',
-              marginBottom: '8px'
-            }}>
-              {['START', 'SELECT', 'A', 'B'].map(button => (
-                <button
-                  key={button}
-                  onClick={() => handleTestButton(button)}
-                  style={{
-                    padding: '6px 8px',
-                    fontSize: '10px',
-                    background: testButtonPressed === button 
-                      ? 'linear-gradient(145deg, #ef4444, #dc2626)' 
-                      : 'linear-gradient(145deg, #6b7280, #4b5563)',
-                    color: 'white',
-                    border: 'none',
-                    borderRadius: '4px',
-                    cursor: 'pointer',
-                    fontWeight: 'bold'
-                  }}
-                >
-                  {button}
-                </button>
-              ))}
-            </div>
-            <div style={{
-              display: 'grid',
-              gridTemplateColumns: 'repeat(4, 1fr)',
-              gap: '4px'
-            }}>
-              {['UP', 'DOWN', 'LEFT', 'RIGHT'].map(button => (
-                <button
-                  key={button}
-                  onClick={() => handleTestButton(button)}
-                  style={{
-                    padding: '6px 8px',
-                    fontSize: '10px',
-                    background: testButtonPressed === button 
-                      ? 'linear-gradient(145deg, #ef4444, #dc2626)' 
-                      : 'linear-gradient(145deg, #6b7280, #4b5563)',
-                    color: 'white',
-                    border: 'none',
-                    borderRadius: '4px',
-                    cursor: 'pointer',
-                    fontWeight: 'bold'
-                  }}
-                >
-                  {button}
-                </button>
-              ))}
-            </div>
-            <div style={{
-              marginTop: '8px',
-              fontSize: '10px',
-              color: '#4b5563',
-              textAlign: 'center'
-            }}>
-              Test buttons to verify input works • Check browser console for debug info
-            </div>
-          </div>
-        )}
       </div>
     );
   }

--- a/src/index.css
+++ b/src/index.css
@@ -2,20 +2,22 @@
   box-sizing: border-box;
 }
 
+html,
 body {
   margin: 0;
   padding: 0;
+  height: 100vh;
+  overflow: hidden;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  min-height: 100vh;
 }
 
 #root {
-  min-height: 100vh;
+  height: 100%;
   display: flex;
   flex-direction: column;
 }
@@ -49,8 +51,8 @@ body {
 
 .screen-content {
   background: #9bb563;
-  width: 320px;
-  height: 288px;
+  width: 480px;
+  height: 432px;
   border: 2px solid #1e2124;
   position: relative;
   margin: 0 auto;
@@ -172,31 +174,61 @@ body {
   border-bottom: none;
 }
 
-.grid {
-  display: grid;
-  gap: 20px;
+
+/* Layout for single-viewport UI */
+.main-container {
+  display: flex;
+  height: 100%;
+  width: 100%;
 }
 
-.grid-2 {
-  grid-template-columns: 2fr 1fr;
+.left-column {
+  flex: 0 0 520px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1rem;
+  box-sizing: border-box;
 }
 
-.grid-3 {
-  grid-template-columns: 2fr 1fr 1fr;
+.right-column {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  padding: 1rem;
+  box-sizing: border-box;
+}
+
+.right-column section {
+  flex: 0 0 auto;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.activity-log {
+  flex: 1 1 auto;
+  max-height: 200px;
+  overflow-y: auto;
 }
 
 @media (max-width: 768px) {
-  .grid-2,
-  .grid-3 {
-    grid-template-columns: 1fr;
+  .left-column {
+    flex-basis: 420px;
   }
-  
-  .container {
-    padding: 10px;
+
+  #wasmboy-canvas {
+    width: 320px !important;
+    height: 288px !important;
   }
-  
-  .screen-content {
-    width: 280px;
-    height: 252px;
-  }
-} 
+}
+
+/* Ensure the GameBoy canvas scales correctly */
+#wasmboy-canvas {
+  width: 480px !important;
+  height: 432px !important;
+  image-rendering: pixelated !important;
+}
+


### PR DESCRIPTION
## Summary
- replace grid layout with fixed two-column flex container
- move emulator header to right column
- ensure GameBoy canvas resizes correctly

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_683f657d8ba4832f8b3c399c2a4b8bbe