### PR TITLE
Improve layout and styling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -106,9 +106,9 @@ function App() {
 
   return (
     <div className="app-container container">
-      <header style={{ textAlign: 'center', padding: '10px 0' }}>
-        <h1 style={{ color: 'white', margin: 0 }}>🎮 GameBoy AI Player</h1>
-        <div style={{ color: 'rgba(255,255,255,0.6)', fontSize: '0.8rem' }}>v{APP_VERSION}</div>
+      <header className="app-header">
+        <h1 className="app-title">🎮 GameBoy AI Player</h1>
+        <div className="app-version">v{APP_VERSION}</div>
       </header>
 
       <div className="main-grid">

--- a/src/components/GameBoyControls.tsx
+++ b/src/components/GameBoyControls.tsx
@@ -60,7 +60,7 @@ const GameBoyControls: React.FC<GameBoyControlsProps> = ({ onButtonPress, onButt
   };
 
   return (
-    <div className="controls-panel">
+    <div className="controls-panel game-controls">
       <h3 style={{ 
         color: 'white', 
         margin: '0 0 16px 0',

--- a/src/components/GameBoyEmulator.tsx
+++ b/src/components/GameBoyEmulator.tsx
@@ -443,6 +443,7 @@ const GameBoyEmulator = forwardRef<GameBoyEmulatorRef, GameBoyEmulatorProps>(
 
     return (
         <div
+          className="emulator-wrapper"
           style={{
             background: 'linear-gradient(145deg, #9bb563, #8faa5a)',
             padding: '20px',

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,26 @@ body {
   min-height: 100vh;
 }
 
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  text-align: center;
+  padding: 10px 0;
+  background: rgba(30, 30, 40, 0.85);
+  backdrop-filter: blur(6px);
+}
+
+.app-title {
+  color: white;
+  margin: 0;
+}
+
+.app-version {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.8rem;
+}
+
 #root {
   min-height: 100vh;
   display: flex;
@@ -62,12 +82,19 @@ body {
 }
 
 .controls-panel {
-  background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(10px);
-  border-radius: 16px;
-  padding: 24px;
-  margin: 20px 0;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(30, 30, 40, 0.93);
+  border-radius: 14px;
+  padding: 1.2rem 1.4rem;
+  margin-bottom: 1.2rem;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.14);
+}
+
+.game-controls {
+  margin-top: 2rem;
+  background: rgba(45, 45, 55, 0.92);
+}
+.game-controls button {
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
 }
 
 .button {
@@ -203,26 +230,42 @@ body {
 .left-column {
   display: flex;
   flex-direction: column;
+  align-items: center;
+  justify-content: center;
   gap: 20px;
+}
+
+.emulator-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }
 
 .right-column {
   display: flex;
   flex-direction: column;
   overflow-y: auto;
-  gap: 20px;
+  gap: 1.2rem;
+  padding-right: 0.5rem;
 }
 
-@media (max-width: 768px) {
-  .grid-2,
-  .grid-3 {
+@media (max-width: 900px) {
+  .main-grid {
     grid-template-columns: 1fr;
+    height: auto;
   }
-  
+
+  .right-column,
+  .left-column {
+    width: 100%;
+    min-width: unset;
+  }
+
   .container {
     padding: 10px;
   }
-  
+
   .screen-content {
     width: 320px;
     height: 288px;
@@ -234,5 +277,7 @@ body {
   width: 480px !important;
   height: 432px !important;
   image-rendering: pixelated !important;
+  box-shadow: 0 6px 24px rgba(60, 60, 80, 0.24);
+  border-radius: 12px;
 }
 


### PR DESCRIPTION
## Summary
- polish header styling and make it sticky
- vertically center emulator column
- tweak control panel cards and add styles for game controls
- add responsive CSS for screens under 900px

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68402b4085a0832f97cd4e62709038b3