### PR TITLE
Improve layout styling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -106,7 +106,7 @@ function App() {
 
   return (
     <div className="app-container container">
-      <header style={{ textAlign: 'center', padding: '10px 0' }}>
+      <header className="app-header">
         <h1 style={{ color: 'white', margin: 0 }}>🎮 GameBoy AI Player</h1>
         <div style={{ color: 'rgba(255,255,255,0.6)', fontSize: '0.8rem' }}>v{APP_VERSION}</div>
       </header>

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -88,13 +88,16 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
 
   return (
     <div className="controls-panel">
-      <h3 style={{ 
-        color: 'white', 
-        margin: '0 0 16px 0',
-        display: 'flex',
-        alignItems: 'center',
-        gap: '8px'
-      }}>
+      <h3
+        className="panel-header"
+        style={{
+          color: 'white',
+          margin: '0 0 16px 0',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '8px'
+        }}
+      >
         <Settings size={20} />
         AI Configuration
       </h3>

--- a/src/components/GameBoyControls.tsx
+++ b/src/components/GameBoyControls.tsx
@@ -32,20 +32,21 @@ const GameBoyControls: React.FC<GameBoyControlsProps> = ({ onButtonPress, onButt
     alignItems: 'center',
     justifyContent: 'center',
     fontSize: '12px',
+    boxShadow: '0 2px 6px rgba(0,0,0,0.25)',
     opacity: disabled ? 0.5 : 1
   };
 
   const dpadButtonStyle = {
     ...buttonStyle,
-    width: '40px',
-    height: '40px',
+    width: '50px',
+    height: '50px',
     fontSize: '16px'
   };
 
   const actionButtonStyle = {
     ...buttonStyle,
-    width: '50px',
-    height: '50px',
+    width: '60px',
+    height: '60px',
     borderRadius: '50%',
     fontSize: '14px',
     fontWeight: 'bold'
@@ -53,19 +54,22 @@ const GameBoyControls: React.FC<GameBoyControlsProps> = ({ onButtonPress, onButt
 
   const smallButtonStyle = {
     ...buttonStyle,
-    width: '60px',
-    height: '20px',
+    width: '70px',
+    height: '24px',
     borderRadius: '10px',
     fontSize: '10px'
   };
 
   return (
-    <div className="controls-panel">
-      <h3 style={{ 
-        color: 'white', 
-        margin: '0 0 16px 0',
-        textAlign: 'center'
-      }}>
+    <div className="controls-panel game-controls">
+      <h3
+        className="panel-header"
+        style={{
+          color: 'white',
+          margin: '0 0 16px 0',
+          textAlign: 'center'
+        }}
+      >
         🎮 Game Controls
       </h3>
       

--- a/src/components/GameLog.tsx
+++ b/src/components/GameLog.tsx
@@ -89,13 +89,16 @@ const GameLog: React.FC<GameLogProps> = ({ logs, onClearLogs }) => {
 
   return (
     <div className="controls-panel">
-      <h3 style={{ 
-        color: 'white', 
-        margin: '0 0 16px 0',
-        display: 'flex',
-        alignItems: 'center',
-        gap: '8px'
-      }}>
+      <h3
+        className="panel-header"
+        style={{
+          color: 'white',
+          margin: '0 0 16px 0',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '8px'
+        }}
+      >
         📋 Activity Log
       </h3>
       

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,16 @@ body {
   min-height: 100vh;
 }
 
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  text-align: center;
+  padding: 10px 0;
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(6px);
+}
+
 #root {
   min-height: 100vh;
   display: flex;
@@ -62,12 +72,26 @@ body {
 }
 
 .controls-panel {
-  background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(10px);
-  border-radius: 16px;
-  padding: 24px;
-  margin: 20px 0;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(30, 30, 40, 0.93);
+  border-radius: 14px;
+  padding: 1.2rem 1.4rem;
+  margin-bottom: 1.2rem;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.14);
+}
+
+.game-controls {
+  margin-top: 2rem;
+  background: rgba(45, 45, 55, 0.92);
+  border-radius: 14px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.14);
+  padding: 1.2rem 1.4rem;
+}
+
+h2,
+.panel-header {
+  font-size: 1.3rem;
+  font-weight: 700;
+  margin-bottom: 0.7rem;
 }
 
 .button {
@@ -204,6 +228,8 @@ body {
   display: flex;
   flex-direction: column;
   gap: 20px;
+  align-items: center;
+  justify-content: center;
 }
 
 .right-column {
@@ -213,7 +239,16 @@ body {
   gap: 20px;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 900px) {
+  .app-container {
+    flex-direction: column;
+    height: auto;
+  }
+  .right-column,
+  .left-column {
+    width: 100%;
+    min-width: unset;
+  }
   .grid-2,
   .grid-3 {
     grid-template-columns: 1fr;
@@ -234,5 +269,7 @@ body {
   width: 480px !important;
   height: 432px !important;
   image-rendering: pixelated !important;
+  box-shadow: 0 6px 24px rgba(60, 60, 80, 0.24);
+  border-radius: 12px;
 }
 


### PR DESCRIPTION
## Summary
- redesign panels with card style and spacing
- center left column contents and tweak responsive layout
- enlarge and style controls
- make header sticky

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68403158c4d8832fb2d8ca8886e9ea59