### PR TITLE
Add button success memory UI

### DIFF
--- a/src/components/AIController.tsx
+++ b/src/components/AIController.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef, useImperativeHandle, useRef } from 'react';
 import axios from 'axios';
 import { AIConfig, GameState, LogEntry } from '../store/gameStore';
+import { useButtonMemoryStore } from '../store/buttonMemoryStore';
 import { GameBoyEmulatorRef } from './GameBoyEmulator'; // Import GameBoyEmulatorRef
 
 interface AIControllerProps {
@@ -24,6 +25,7 @@ const AIController = forwardRef<AIControllerRef, AIControllerProps>(
     // const lastScreenDataRef = useRef<ImageData | null>(null);
     const lastDecisionRef = useRef<string | null>(null);
     const decisionCountRef = useRef<{ [key: string]: number }>({});
+    const recordButtonSuccess = useButtonMemoryStore(state => state.recordSuccess);
 
     useImperativeHandle(ref, () => ({
       startPlaying: () => {
@@ -209,6 +211,7 @@ const AIController = forwardRef<AIControllerRef, AIControllerProps>(
               }
               if (pixelsDifferent > 0) {
                 onLog('ai', `✅ Button ${decision} caused screen change (${pixelsDifferent} pixels)`);
+                recordButtonSuccess(decision);
               } else {
                 onLog('ai', `⚠️ Button ${decision} did not change screen`);
               }

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Settings, Cpu } from 'lucide-react';
 import { AIConfig, GameState } from '../store/gameStore';
+import { useButtonMemoryStore } from '../store/buttonMemoryStore';
 
 interface ControlPanelProps {
   aiConfig: AIConfig;
@@ -27,6 +28,7 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
   const [availableModels, setAvailableModels] = useState<OpenRouterModel[]>([]);
   const [isLoadingModels, setIsLoadingModels] = useState(false);
   const [modelError, setModelError] = useState<string | null>(null);
+  const { successCounts, clearMemory } = useButtonMemoryStore();
 
   // Fetch available models from OpenRouter
   useEffect(() => {
@@ -367,14 +369,44 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
           <div>Game: {gameState.currentGame || 'None loaded'}</div>
           <div>Status: {gameState.isPlaying ? 'Playing' : 'Paused'}</div>
           <div>AI: {gameState.aiEnabled ? 'Enabled' : 'Disabled'}</div>
-          <div>AI Status: <span style={{ 
-            color: gameState.aiStatus === 'playing' ? '#22c55e' : 
-                   gameState.aiStatus === 'thinking' ? '#fbbf24' : 
+          <div>AI Status: <span style={{
+            color: gameState.aiStatus === 'playing' ? '#22c55e' :
+                   gameState.aiStatus === 'thinking' ? '#fbbf24' :
                    gameState.aiStatus === 'error' ? '#f87171' : '#9ca3af'
           }}>
             {gameState.aiStatus}
           </span></div>
         </div>
+      </div>
+
+      {/* Button Success Stats */}
+      <div style={{
+        marginTop: '20px',
+        padding: '12px',
+        background: 'rgba(0,0,0,0.2)',
+        borderRadius: '8px',
+        fontSize: '12px'
+      }}>
+        <div style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: '8px'
+        }}>
+          <span style={{ fontWeight: 'bold', color: 'white' }}>Button Success Stats</span>
+          <button className="button" style={{ fontSize: '10px', padding: '4px 8px' }} onClick={clearMemory}>
+            Clear Memory
+          </button>
+        </div>
+        {Object.keys(successCounts).length === 0 ? (
+          <div style={{ fontStyle: 'italic', color: 'rgba(255,255,255,0.6)' }}>No data yet</div>
+        ) : (
+          <ul style={{ listStyle: 'none', padding: 0, margin: 0, color: 'rgba(255,255,255,0.8)' }}>
+            {Object.entries(successCounts).map(([btn, count]) => (
+              <li key={btn} style={{ marginBottom: '4px' }}>{btn}: {count}</li>
+            ))}
+          </ul>
+        )}
       </div>
 
       {/* Instructions */}

--- a/src/store/buttonMemoryStore.ts
+++ b/src/store/buttonMemoryStore.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export interface ButtonMemoryState {
+  successCounts: Record<string, number>;
+}
+
+type ButtonMemoryStore = ButtonMemoryState & {
+  recordSuccess: (button: string) => void;
+  clearMemory: () => void;
+};
+
+export const useButtonMemoryStore = create<ButtonMemoryStore>()(
+  persist(
+    (set) => ({
+      successCounts: {},
+      recordSuccess: (button) =>
+        set((state) => ({
+          successCounts: {
+            ...state.successCounts,
+            [button]: (state.successCounts[button] || 0) + 1,
+          },
+        })),
+      clearMemory: () => set({ successCounts: {} }),
+    }),
+    { name: 'gameboy-button-memory' }
+  )
+);


### PR DESCRIPTION
## Summary
- store button success counts with zustand
- log success in `AIController`
- show button stats in `ControlPanel`
- add button to clear button memory

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_684039198054832f9a6e1aa56a6acd9f