### PR TITLE
Disable browser auto-open in Vite

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000,
-    open: true
+    open: false
   },
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- avoid automatic browser launch when running dev server

## Testing
- `npm run lint` *(fails: missing eslint.config)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684069694750832fa5962e8c50b1c391